### PR TITLE
Seedの判定をIDベースにした

### DIFF
--- a/lib/define.js
+++ b/lib/define.js
@@ -20,7 +20,7 @@ function define (db, pattern, options = {}) {
   let {
     env = process.env.NODE_ENV || 'development',
     resolver = (filename) => path.basename(filename).split('.')[ 0 ],
-    seedKey = '$$seed'
+    seedKey = 'id'
   } = options
 
   function task (ctx) {


### PR DESCRIPTION
テストデータを作成する時、すでに作成済みかどうかの判定をして、済みなら何もしない的な挙動になっている。

以前はIDは完全に自動付与なので別の項目を用意しなければならなかったが、

https://github.com/realglobe-Inc/clay-driver-memory/pull/11

で独自に割り振れるようになったので、IDベースへ変更した