### PR TITLE
Seedのidがないときに警告を出すようにした

### DIFF
--- a/lib/define.js
+++ b/lib/define.js
@@ -36,6 +36,9 @@ function define (db, pattern, options = {}) {
         const resource = instance.resource(resourceName)
         let attributesArray = require(path.resolve(filename))
         for (let attributes of attributesArray) {
+          if (!attributes.hasOwnProperty(seedKey)) {
+            logger.warn(`SeedKey "${seedKey}" is missing for entry: ${JSON.stringify(attributes)}`)
+          }
           let key = attributes[ seedKey ]
           let skip = key && (yield resource.exists({ [seedKey]: key }))
           if (skip) {


### PR DESCRIPTION
db:seedを複数回実行したときに、idをみて再追加するべきかどうかを決めている。
ないと実行するたびにデータがどんどん増えてしまうのでその警告を出すようにした